### PR TITLE
fix: Fix regex issue for older Elixir + Erlang/OTP

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,20 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: '1.15'
-            otp: '26'
-            os: ubuntu-22.04
-          - elixir: '1.16'
-            otp: '26'
-            os: ubuntu-22.04
-          - elixir: '1.17'
-            otp: '27'
-            os: ubuntu-22.04
           - elixir: '1.18'
             otp: '27'
             os: ubuntu-22.04
           - elixir: '1.19'
-            otp: '28.1'
+            otp: '28.3'
             os: ubuntu-22.04
             check_formatted: true
             warnings_as_errors: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,5 +2,5 @@
 ERL_AFLAGS = "-kernel shell_history enabled shell_history_file_bytes 5242880"
 
 [tools]
-elixir = "1.19.2-otp-28"
-erlang = "28.1.1"
+elixir = "1.19.4-otp-28"
+erlang = "28.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TableauExcerptExtension Changelog
 
-## 1.0.0 / 2025-12-23
+## 1.0.1 / 2025-12-26
+
+- Updated the version requirements and fixed a problem where a regular
+  expression isn't supported by older versions of Elixir and Erlang/OTP.
+
+## 1.0.0 / 2025-12-25
 
 - Initial release.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TableauExcerptExtension.MixProject do
 
   @app :tableau_excerpt_extension
   @project_url "https://github.com/halostatue/tableau_excerpt_extension"
-  @version "1.0.0"
+  @version "1.0.1"
 
   def project do
     [
@@ -12,7 +12,7 @@ defmodule TableauExcerptExtension.MixProject do
       version: @version,
       source_url: @project_url,
       name: "TableauExcerptExtension",
-      elixir: "~> 1.15",
+      elixir: "~> 1.18",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,69 @@
+defmodule ConfigTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  describe "config/1" do
+    test "accepts keyword list config" do
+      assert {:ok, %{enabled: true}} = TableauExcerptExtension.config(enabled: true)
+    end
+
+    test "accepts map config" do
+      assert {:ok, %{enabled: true}} = TableauExcerptExtension.config(%{enabled: true})
+    end
+
+    test "defaults enabled to false" do
+      assert {:ok, %{enabled: false}} = TableauExcerptExtension.config(%{})
+    end
+
+    test "accepts fallback and marker as lists" do
+      assert {:ok, %{fallback: %{}, marker: %{}}} =
+               TableauExcerptExtension.config(fallback: [count: 2], marker: [remove: false])
+    end
+
+    test "validates fallback.strategy" do
+      assert {:error, "fallback.strategy must be one of :paragraph, :sentence, or :word, got: :invalid"} =
+               TableauExcerptExtension.config(%{fallback: %{strategy: :invalid}})
+    end
+
+    test "validates fallback.count" do
+      assert {:error, "fallback.count must be a positive integer, got: 0"} =
+               TableauExcerptExtension.config(%{fallback: %{count: 0}})
+
+      assert {:error, "fallback.count must be a positive integer, got: \"invalid\""} =
+               TableauExcerptExtension.config(%{fallback: %{count: "invalid"}})
+    end
+
+    test "validates marker.pattern regex" do
+      assert {:error, "marker.pattern must be a valid regular expression, got: \"[\""} =
+               TableauExcerptExtension.config(%{marker: %{pattern: "["}})
+    end
+
+    test "compiles the marker.pattern regex" do
+      assert {:ok, %{marker: %{pattern: %Regex{}}}} =
+               TableauExcerptExtension.config(%{marker: %{pattern: "<!--\\s*(?:more|fold)\\s*-->"}})
+    end
+
+    test "applies default counts based on strategy" do
+      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :paragraph}})
+      assert config.fallback.count == 1
+
+      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :sentence}})
+      assert config.fallback.count == 2
+
+      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :word}})
+      assert config.fallback.count == 25
+    end
+
+    test "allows marker and fallback to be disabled" do
+      log =
+        capture_log(fn ->
+          assert {:ok, %{enabled: false, fallback: false, marker: false}} =
+                   TableauExcerptExtension.config(%{marker: false, fallback: false})
+        end)
+
+      assert log =~ "[TableauExcerptExtension] Disabling because both marker and fallback"
+      assert log =~ "are disabled"
+    end
+  end
+end

--- a/test/page_test.exs
+++ b/test/page_test.exs
@@ -1,0 +1,198 @@
+defmodule PageTest do
+  use TableauExcerptExtension.PageCase, async: true
+
+  alias Tableau.PostExtension
+
+  describe "integration with PostExtension" do
+    @describetag :tmp_dir
+
+    setup %{tmp_dir: dir} do
+      assert {:ok, post_config} =
+               PostExtension.config(%{
+                 dir: dir,
+                 enabled: true,
+                 layout: Blog.PostLayout
+               })
+
+      token = %{
+        site: %{config: %{converters: [md: Tableau.MDExConverter]}},
+        extensions: %{
+          posts: %{config: post_config},
+          excerpt: %{config: TableauExcerptExtension.PageCase.build_config()}
+        },
+        graph: Graph.new()
+      }
+
+      [token: token]
+    end
+
+    test "processes posts with excerpt markers correctly", %{token: token, tmp_dir: dir} do
+      File.write!(Path.join(dir, "test-post.md"), """
+      ---
+      title: Test Post
+      date: 2024-01-01
+      ---
+
+      This is the excerpt content.
+
+      <!--more-->
+
+      This is the full post content that should not appear in excerpts.
+
+      More content here.
+      """)
+
+      # Process through both extensions
+      {:ok, token} = PostExtension.pre_build(token)
+      {:ok, token} = TableauExcerptExtension.pre_build(token)
+
+      # Verify excerpt was extracted and marker was removed
+      [post] = token.posts
+      assert post.excerpt == "This is the excerpt content."
+      refute String.contains?(post.body, "<!--more-->")
+      assert String.contains?(post.body, "This is the full post content")
+    end
+
+    test "processes multiple posts with different excerpt scenarios", %{token: token, tmp_dir: dir} do
+      # Create multiple posts with different excerpt scenarios
+      File.write!(Path.join(dir, "post-with-marker.md"), """
+      ---
+      title: Post with Marker
+      date: 2024-01-01
+      ---
+
+      First paragraph excerpt.
+
+      <!--more-->
+
+      Full content continues here.
+      """)
+
+      File.write!(Path.join(dir, "post-with-fallback.md"), """
+      ---
+      title: Post with Fallback
+      date: 2024-01-02
+      ---
+
+      This is the first paragraph that should be used as excerpt.
+
+      This is the second paragraph.
+      """)
+
+      File.write!(Path.join(dir, "post-with-existing-excerpt.md"), """
+      ---
+      title: Post with Existing Excerpt
+      date: 2024-01-03
+      excerpt: Custom excerpt from frontmatter
+      ---
+
+      This is the body content.
+
+      <!--more-->
+
+      More body content.
+      """)
+
+      # Process through both extensions
+      {:ok, token} = PostExtension.pre_build(token)
+      {:ok, token} = TableauExcerptExtension.pre_build(token)
+
+      # Verify excerpts were processed correctly
+      posts_by_title = Map.new(token.posts, &{&1.title, &1})
+
+      # Post with marker: excerpt extracted, marker removed
+      marker_post = posts_by_title["Post with Marker"]
+      assert marker_post.excerpt == "First paragraph excerpt."
+      refute String.contains?(marker_post.body, "<!--more-->")
+
+      # Post with fallback: first paragraph used as excerpt
+      fallback_post = posts_by_title["Post with Fallback"]
+      assert fallback_post.excerpt == "This is the first paragraph that should be used as excerpt."
+
+      # Post with existing excerpt: preserved unchanged, body not modified
+      existing_post = posts_by_title["Post with Existing Excerpt"]
+      assert existing_post.excerpt == "Custom excerpt from frontmatter"
+      # Body should be unchanged since excerpt already exists
+      assert String.contains?(existing_post.body, "<!--more-->")
+    end
+
+    test "preserves marker in body when configured", %{token: token, tmp_dir: dir} do
+      # Configure to preserve marker
+      preserve_config = TableauExcerptExtension.PageCase.build_config(marker: %{remove: false})
+      token = put_in(token.extensions.excerpt.config, preserve_config)
+
+      File.write!(Path.join(dir, "preserve-marker-post.md"), """
+      ---
+      title: Preserve Marker Post
+      date: 2024-01-01
+      ---
+
+      Excerpt content here.
+
+      <!--more-->
+
+      Full content after marker.
+      """)
+
+      # Process through both extensions
+      {:ok, token} = PostExtension.pre_build(token)
+      {:ok, token} = TableauExcerptExtension.pre_build(token)
+
+      [post] = token.posts
+      assert post.excerpt == "Excerpt content here."
+      # Verify marker was preserved in body
+      assert String.contains?(post.body, "<!--more-->")
+    end
+
+    test "handles reference links in excerpts", %{token: token, tmp_dir: dir} do
+      File.write!(Path.join(dir, "reference-links-post.md"), """
+      ---
+      title: Reference Links Post
+      date: 2024-01-01
+      ---
+
+      Check out [this link][ref] for more info.
+
+      <!--more-->
+
+      More content here.
+
+      [ref]: https://example.com "Example Site"
+      """)
+
+      # Process through both extensions
+      {:ok, token} = PostExtension.pre_build(token)
+      {:ok, token} = TableauExcerptExtension.pre_build(token)
+
+      [post] = token.posts
+      # Reference link should be converted to inline link in excerpt
+      assert post.excerpt == ~s|Check out [this link](https://example.com "Example Site") for more info.|
+      # Original body should still have reference definition
+      assert String.contains?(post.body, "[ref]: https://example.com")
+    end
+
+    test "handles different fallback strategies", %{token: token, tmp_dir: dir} do
+      # Configure word-based fallback
+      word_config = TableauExcerptExtension.PageCase.build_config(fallback: %{strategy: :word, count: 5, more: "..."})
+      token = put_in(token.extensions.excerpt.config, word_config)
+
+      File.write!(Path.join(dir, "word-fallback-post.md"), """
+      ---
+      title: Word Fallback Post
+      date: 2024-01-01
+      ---
+
+      This is a very long sentence with many words that should be truncated.
+
+      Second paragraph here.
+      """)
+
+      # Process through both extensions
+      {:ok, token} = PostExtension.pre_build(token)
+      {:ok, token} = TableauExcerptExtension.pre_build(token)
+
+      [post] = token.posts
+      assert post.excerpt == "This is a very long..."
+    end
+  end
+end

--- a/test/tableau_excerpt_extension_test.exs
+++ b/test/tableau_excerpt_extension_test.exs
@@ -1,74 +1,6 @@
 defmodule TableauExcerptExtensionTest do
   use TableauExcerptExtension.PageCase, async: true
 
-  alias Tableau.PostExtension
-
-  describe "config/1" do
-    test "accepts keyword list config" do
-      assert {:ok, %{enabled: true}} = TableauExcerptExtension.config(enabled: true)
-    end
-
-    test "accepts map config" do
-      assert {:ok, %{enabled: true}} = TableauExcerptExtension.config(%{enabled: true})
-    end
-
-    test "defaults enabled to false" do
-      assert {:ok, %{enabled: false}} = TableauExcerptExtension.config(%{})
-    end
-
-    test "accepts fallback and marker as lists" do
-      assert {:ok, %{fallback: %{}, marker: %{}}} =
-               TableauExcerptExtension.config(fallback: [count: 2], marker: [remove: false])
-    end
-
-    test "validates fallback.strategy" do
-      assert {:error, "fallback.strategy must be one of :paragraph, :sentence, or :word, got: :invalid"} =
-               TableauExcerptExtension.config(%{fallback: %{strategy: :invalid}})
-    end
-
-    test "validates fallback.count" do
-      assert {:error, "fallback.count must be a positive integer, got: 0"} =
-               TableauExcerptExtension.config(%{fallback: %{count: 0}})
-
-      assert {:error, "fallback.count must be a positive integer, got: \"invalid\""} =
-               TableauExcerptExtension.config(%{fallback: %{count: "invalid"}})
-    end
-
-    test "validates marker.pattern regex" do
-      assert {:error, "marker.pattern must be a valid regular expression, got: \"[\""} =
-               TableauExcerptExtension.config(%{marker: %{pattern: "["}})
-    end
-
-    test "compiles the marker.pattern regex" do
-      assert {:ok, %{marker: %{pattern: %Regex{}}}} =
-               TableauExcerptExtension.config(%{marker: %{pattern: "<!--\\s*(?:more|fold)\\s*-->"}})
-    end
-
-    test "applies default counts based on strategy" do
-      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :paragraph}})
-      assert config.fallback.count == 1
-
-      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :sentence}})
-      assert config.fallback.count == 2
-
-      {:ok, config} = TableauExcerptExtension.config(%{fallback: %{strategy: :word}})
-      assert config.fallback.count == 25
-    end
-
-    test "allows marker and fallback to be disabled" do
-      import ExUnit.CaptureLog
-
-      log =
-        capture_log(fn ->
-          assert {:ok, %{enabled: false, fallback: false, marker: false}} =
-                   TableauExcerptExtension.config(%{marker: false, fallback: false})
-        end)
-
-      assert log =~ "[TableauExcerptExtension] Disabling because both marker and fallback"
-      assert log =~ "are disabled"
-    end
-  end
-
   describe "excerpt processing" do
     test "adds excerpt to posts without one" do
       body = "First paragraph.\n\nSecond paragraph."
@@ -142,6 +74,106 @@ defmodule TableauExcerptExtensionTest do
         )
 
       assert excerpt == "First sentence here. Second sentence follows."
+    end
+
+    test "handles question marks in sentence fallback" do
+      body = """
+      What is this? Another question follows? A third one too.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == "What is this? Another question follows?"
+    end
+
+    test "handles exclamation marks in sentence fallback" do
+      body = """
+      Look out! Another exclamation follows! A third one too.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == "Look out! Another exclamation follows!"
+    end
+
+    test "handles mixed punctuation in sentence fallback" do
+      body = """
+      This is a statement. Is this a question? Yes, it is! More content follows.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 3})
+      assert excerpt == "This is a statement. Is this a question? Yes, it is!"
+    end
+
+    test "handles quotes after punctuation in sentence fallback" do
+      body = """
+      He said "Hello." She replied "Goodbye." They parted ways.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == ~s|He said "Hello." She replied "Goodbye."|
+    end
+
+    test "handles quotes before punctuation in sentence fallback" do
+      body = """
+      He said "Hello". She replied "Goodbye". They parted ways.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == ~s|He said "Hello". She replied "Goodbye".|
+    end
+
+    test "handles single quotes in sentence fallback" do
+      body = """
+      He said 'Hello.' She replied 'Goodbye.' They parted ways.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == "He said 'Hello.' She replied 'Goodbye.'"
+    end
+
+    test "handles unicode punctuation in sentence fallback" do
+      body = """
+      Really‽ Another interrobang follows‽ A third one too.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == "Really‽ Another interrobang follows‽"
+    end
+
+    test "handles complex quote combinations in sentence fallback" do
+      body = """
+      She asked "Are you sure?" He replied "Absolutely!" They agreed.
+
+      Second paragraph.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      assert excerpt == ~s|She asked "Are you sure?" He replied "Absolutely!"|
+    end
+
+    test "handles sentences with no ending punctuation" do
+      body = """
+      This sentence has no ending
+
+      This one does. Another follows.
+      """
+
+      excerpt = process_page(body, fallback: %{strategy: :sentence, count: 2})
+      # Should take the incomplete sentence since it's the first paragraph
+      assert excerpt == "This sentence has no ending"
     end
 
     test "converts reference links to inline links" do
@@ -341,199 +373,6 @@ defmodule TableauExcerptExtensionTest do
       # Configure word fallback with count higher than actual words
       excerpt = process_page(body, fallback: %{strategy: :word, count: 10, more: "..."})
       assert excerpt == "Short paragraph."
-    end
-  end
-
-  describe "integration with PostExtension" do
-    @describetag :tmp_dir
-
-    setup %{tmp_dir: dir} do
-      assert {:ok, post_config} =
-               PostExtension.config(%{
-                 dir: dir,
-                 enabled: true,
-                 layout: Blog.PostLayout
-               })
-
-      token = %{
-        site: %{config: %{converters: [md: Tableau.MDExConverter]}},
-        extensions: %{
-          posts: %{config: post_config},
-          excerpt: %{config: TableauExcerptExtension.PageCase.build_config()}
-        },
-        graph: Graph.new()
-      }
-
-      [token: token]
-    end
-
-    test "processes posts with excerpt markers correctly", %{token: token, tmp_dir: dir} do
-      File.write!(Path.join(dir, "test-post.md"), """
-      ---
-      title: Test Post
-      date: 2024-01-01
-      ---
-
-      This is the excerpt content.
-
-      <!--more-->
-
-      This is the full post content that should not appear in excerpts.
-
-      More content here.
-      """)
-
-      # Process through both extensions
-      {:ok, token} = PostExtension.pre_build(token)
-      {:ok, token} = TableauExcerptExtension.pre_build(token)
-
-      # Verify excerpt was extracted and marker was removed
-      [post] = token.posts
-      assert post.excerpt == "This is the excerpt content."
-      refute String.contains?(post.body, "<!--more-->")
-      assert String.contains?(post.body, "This is the full post content")
-    end
-
-    test "processes multiple posts with different excerpt scenarios", %{token: token, tmp_dir: dir} do
-      # Create multiple posts with different excerpt scenarios
-      File.write!(Path.join(dir, "post-with-marker.md"), """
-      ---
-      title: Post with Marker
-      date: 2024-01-01
-      ---
-
-      First paragraph excerpt.
-
-      <!--more-->
-
-      Full content continues here.
-      """)
-
-      File.write!(Path.join(dir, "post-with-fallback.md"), """
-      ---
-      title: Post with Fallback
-      date: 2024-01-02
-      ---
-
-      This is the first paragraph that should be used as excerpt.
-
-      This is the second paragraph.
-      """)
-
-      File.write!(Path.join(dir, "post-with-existing-excerpt.md"), """
-      ---
-      title: Post with Existing Excerpt
-      date: 2024-01-03
-      excerpt: Custom excerpt from frontmatter
-      ---
-
-      This is the body content.
-
-      <!--more-->
-
-      More body content.
-      """)
-
-      # Process through both extensions
-      {:ok, token} = PostExtension.pre_build(token)
-      {:ok, token} = TableauExcerptExtension.pre_build(token)
-
-      # Verify excerpts were processed correctly
-      posts_by_title = Map.new(token.posts, &{&1.title, &1})
-
-      # Post with marker: excerpt extracted, marker removed
-      marker_post = posts_by_title["Post with Marker"]
-      assert marker_post.excerpt == "First paragraph excerpt."
-      refute String.contains?(marker_post.body, "<!--more-->")
-
-      # Post with fallback: first paragraph used as excerpt
-      fallback_post = posts_by_title["Post with Fallback"]
-      assert fallback_post.excerpt == "This is the first paragraph that should be used as excerpt."
-
-      # Post with existing excerpt: preserved unchanged, body not modified
-      existing_post = posts_by_title["Post with Existing Excerpt"]
-      assert existing_post.excerpt == "Custom excerpt from frontmatter"
-      # Body should be unchanged since excerpt already exists
-      assert String.contains?(existing_post.body, "<!--more-->")
-    end
-
-    test "preserves marker in body when configured", %{token: token, tmp_dir: dir} do
-      # Configure to preserve marker
-      preserve_config = TableauExcerptExtension.PageCase.build_config(marker: %{remove: false})
-      token = put_in(token.extensions.excerpt.config, preserve_config)
-
-      File.write!(Path.join(dir, "preserve-marker-post.md"), """
-      ---
-      title: Preserve Marker Post
-      date: 2024-01-01
-      ---
-
-      Excerpt content here.
-
-      <!--more-->
-
-      Full content after marker.
-      """)
-
-      # Process through both extensions
-      {:ok, token} = PostExtension.pre_build(token)
-      {:ok, token} = TableauExcerptExtension.pre_build(token)
-
-      [post] = token.posts
-      assert post.excerpt == "Excerpt content here."
-      # Verify marker was preserved in body
-      assert String.contains?(post.body, "<!--more-->")
-    end
-
-    test "handles reference links in excerpts", %{token: token, tmp_dir: dir} do
-      File.write!(Path.join(dir, "reference-links-post.md"), """
-      ---
-      title: Reference Links Post
-      date: 2024-01-01
-      ---
-
-      Check out [this link][ref] for more info.
-
-      <!--more-->
-
-      More content here.
-
-      [ref]: https://example.com "Example Site"
-      """)
-
-      # Process through both extensions
-      {:ok, token} = PostExtension.pre_build(token)
-      {:ok, token} = TableauExcerptExtension.pre_build(token)
-
-      [post] = token.posts
-      # Reference link should be converted to inline link in excerpt
-      assert post.excerpt == ~s|Check out [this link](https://example.com "Example Site") for more info.|
-      # Original body should still have reference definition
-      assert String.contains?(post.body, "[ref]: https://example.com")
-    end
-
-    test "handles different fallback strategies", %{token: token, tmp_dir: dir} do
-      # Configure word-based fallback
-      word_config = TableauExcerptExtension.PageCase.build_config(fallback: %{strategy: :word, count: 5, more: "..."})
-      token = put_in(token.extensions.excerpt.config, word_config)
-
-      File.write!(Path.join(dir, "word-fallback-post.md"), """
-      ---
-      title: Word Fallback Post
-      date: 2024-01-01
-      ---
-
-      This is a very long sentence with many words that should be truncated.
-
-      Second paragraph here.
-      """)
-
-      # Process through both extensions
-      {:ok, token} = PostExtension.pre_build(token)
-      {:ok, token} = TableauExcerptExtension.pre_build(token)
-
-      [post] = token.posts
-      assert post.excerpt == "This is a very long..."
     end
   end
 end


### PR DESCRIPTION
Older versions of Erlang :re don't support arbitrary length lookbehind assertions, resulting in:

```
** (Regex.CompileError) lookbehind assertion is not fixed length at position 19
```

There was also a warning that yaml_elixir requires Elixir 1.18 or higher, so the minimum version of Elixir is 1.18.

Signed-off-by: Austin Ziegler <austin@zieglers.ca>